### PR TITLE
fix: add failsafe re-scan for streamed messages missed by MutationObserver

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -444,6 +444,26 @@ function getMutationObserverScript() {
     startObserving();
   }
 
+  // Failsafe periodic re-scan: catches mutations the primary observer misses.
+  // Claude Code 2.1.x appears to append some streamed message subtrees in ways
+  // that don't bubble up as childList/characterData mutations on activeContainer
+  // (likely React Portal or virtual-list mount points outside the observed
+  // subtree). Users see this as "new messages never render math until I switch
+  // conversations and back" — because switching re-mounts messagesContainer and
+  // triggers observeMessages() -> renderMath() as a full rescue scan.
+  //
+  // This timer automates that rescue. It does NOT replace or tune the primary
+  // debouncedRender path. Cost is near-zero because:
+  //   - isRendering guard prevents overlap with the primary observer
+  //   - visibilityState check skips background tabs
+  //   - preprocessMath finds no $ on nodes already converted to \(...\)
+  //   - renderMathInElement skips .katex nodes via ignoredClasses
+  setInterval(function() {
+    if (!isRendering && activeContainer && document.visibilityState === 'visible') {
+      renderMath();
+    }
+  }, 700);
+
   console.log('[KaTeX Patch] LaTeX rendering enabled');
 })();`;
 }

--- a/extension.test.js
+++ b/extension.test.js
@@ -331,6 +331,14 @@ describe('getMutationObserverScript', () => {
     expect(script).toContain("display: false");
   });
 
+  test('includes failsafe periodic re-scan guarded by isRendering and visibility', () => {
+    // Rescues messages whose DOM mutations the primary observer misses
+    // (e.g. React Portal / virtual list subtrees in Claude Code 2.1.x).
+    expect(script).toContain('setInterval');
+    expect(script).toContain('visibilityState');
+    expect(script).toMatch(/!isRendering[\s\S]*activeContainer[\s\S]*visibilityState/);
+  });
+
   test('ignores pre and code tags', () => {
     expect(script).toContain("'pre'");
     expect(script).toContain("'code'");


### PR DESCRIPTION
## Symptom

On Claude Code 2.1.x (observed on 2.1.114), new streamed messages **never render math** until the user switches to another conversation and back. Math typed or pasted *before* the conversation was first opened renders fine. This is distinct from #2 (flickering during streaming) — here the math simply never converts until a remount.

The diagnostic signal is that switching conversations *rescues* previously-stuck messages. That maps directly to `rootObserver` firing when `messagesContainer` unmounts/remounts, which calls `observeMessages()` → `renderMath()` as a full subtree scan.

## Root cause

The primary `MutationObserver` in `getMutationObserverScript()` subscribes to the `[class*=\"messagesContainer\"]` element with `{ childList: true, subtree: true, characterData: true }`. In the current Claude Code webview, some streamed message subtrees are mounted in a way that does **not** surface as mutations on that observed subtree — most likely via a React Portal or a virtualized list mount point outside `activeContainer`. The observer never fires for those mutations, `debouncedRender` is never scheduled, and the math stays as raw `$...$`.

The only thing that currently rescues it is `rootObserver` detecting `messagesContainer` itself being replaced, which only happens on conversation switch.

## Fix

Add a 700 ms periodic rescue scan guarded by three conditions:

```js
setInterval(function() {
  if (!isRendering && activeContainer && document.visibilityState === 'visible') {
    renderMath();
  }
}, 700);
```

This does **not** touch the `debouncedRender` path — the primary observer-driven flow is unchanged. The interval only fires when:
- no render is already in progress (`!isRendering`),
- there is an active message container to scan, and
- the webview tab is actually visible.

## Why this is cheap

- `renderMathInElement` skips `.katex` nodes via `ignoredClasses`, so already-rendered math is ignored.
- `preprocessMath` walks text nodes but finds no `\$` on nodes already rewritten to `\(...\)`, so it no-ops.
- `isRendering` guard prevents overlap with the primary observer path.
- `visibilityState === 'visible'` eliminates cost on background webviews.

The practical cost on a fully-rendered conversation is a DOM walk that finds nothing to do, every 700 ms, only while the tab is visible.

## Why this is orthogonal to #2

#2 proposed increasing the debounce delay to reduce flicker during streaming. The reply (\"It feels like this suggestion will not necessarily improve the UX\") rejected that change. This PR does not change debounce timing — it adds a rescue path for a different symptom (non-rendering, not flickering). The two concerns are independent; if #2's proposal were reconsidered later, it would compose cleanly with this.

## Testing

- All existing 69 Jest tests pass.
- Added one test in `extension.test.js` under `describe('getMutationObserverScript', ...)` asserting the patch script contains `setInterval`, `visibilityState`, and the `!isRendering ... activeContainer ... visibilityState` guard pattern.
- Manually verified against Claude Code 2.1.114 on Windows: streamed messages that previously required a conversation-switch to render now render within ~700 ms of streaming completing.

## Test plan

- [ ] `npm test` passes
- [ ] Package with `npx @vscode/vsce package --no-dependencies`, install the VSIX, reload VS Code
- [ ] In a fresh Claude Code conversation, ask for a LaTeX response and confirm math renders without needing to switch conversations
- [ ] Confirm no visible flicker or repeated re-render on a fully-rendered conversation (observer + interval both no-op)