### PR TITLE
fix: render all streamed math, not just the last paragraph (closes #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.7.2] - 2026-04-21
+
+### Fixed
+- Streaming messages with multiple math expressions now render all math, not just the last paragraph. Previously, rapid `characterData` mutations during streaming would overwrite the debounce closure's `mutations` argument, so only the last batch was processed — most paragraphs' math was never rendered and the message stayed as raw `$...$` until the user reloaded the window.
+
+### Changed
+- `renderNewNodes` replaced by `renderDirtyMessages`, which walks up from each mutation target to its `[data-testid="assistant-message"]` ancestor and renders the whole message. Handles characterData mutations, text-node additions, and element additions uniformly. No more `nodeType === 1` filter that silently skipped text-node additions.
+- Mutations now accumulate across debounce callbacks (`pendingMutations`) instead of the closure capturing only the latest batch.
+
 ## [1.7.1] - 2026-04-03
 
 ### Added

--- a/extension.js
+++ b/extension.js
@@ -340,56 +340,48 @@ function getMutationObserverScript() {
     }
   }
 
-  // Process only newly added nodes instead of the whole container
-  function renderNewNodes(mutations) {
+  // Render dirty assistant messages. Each mutation inside messagesContainer
+  // belongs to some assistant message subtree; we collect those, dedupe, and
+  // render each one. Rendering is idempotent: renderMathInElement skips .katex
+  // nodes via ignoredClasses, and preprocessMath returns early on blocks with
+  // no '$'. So re-rendering already-rendered content is effectively free.
+  function renderDirtyMessages(mutations) {
     if (isRendering) return;
     if (typeof renderMathInElement !== 'function') return;
+    var container = document.querySelector(SELECTOR);
+    if (!container) return;
 
-    var nodesToRender = [];
+    var dirty = new Set();
     for (var i = 0; i < mutations.length; i++) {
-      var m = mutations[i];
-      if (m.type === 'characterData') {
-        // Text changed in an existing node - render its parent element
-        var parentEl = m.target.parentElement;
-        if (parentEl && !parentEl.closest('.katex,.katex-display') && hasMathContent(parentEl)) {
-          nodesToRender.push(parentEl);
-        }
-      } else if (m.addedNodes.length > 0) {
-        for (var j = 0; j < m.addedNodes.length; j++) {
-          var node = m.addedNodes[j];
-          if (node.nodeType === 1 && !node.classList.contains('katex') &&
-              !node.classList.contains('katex-display') && hasMathContent(node)) {
-            nodesToRender.push(node);
-          }
-        }
-      }
+      var target = mutations[i].target;
+      var el = target.nodeType === 1 ? target : target.parentElement;
+      if (!el || !el.isConnected) continue;
+      if (el.closest('.katex,.katex-display')) continue;
+      var msg = el.closest('[data-testid=\"assistant-message\"]');
+      dirty.add(msg || container);
     }
 
-    if (nodesToRender.length === 0) return;
+    if (dirty.size === 0) return;
 
     isRendering = true;
     try {
-      // Deduplicate: skip nodes that are children of other nodes in the list
-      var unique = nodesToRender.filter(function(node, idx) {
-        for (var k = 0; k < nodesToRender.length; k++) {
-          if (k !== idx && nodesToRender[k].contains(node)) return false;
-        }
-        return node.isConnected !== false; // skip detached nodes
-      });
-
-      for (var n = 0; n < unique.length; n++) {
-        renderElement(unique[n]);
-      }
+      dirty.forEach(function(el) { renderElement(el); });
     } finally {
       isRendering = false;
     }
   }
 
+  var pendingMutations = [];
   function debouncedRender(mutations) {
+    if (mutations && mutations.length) {
+      for (var i = 0; i < mutations.length; i++) pendingMutations.push(mutations[i]);
+    }
     if (renderTimeout) clearTimeout(renderTimeout);
     renderTimeout = setTimeout(function() {
-      if (mutations && mutations.length > 0) {
-        renderNewNodes(mutations);
+      var batch = pendingMutations;
+      pendingMutations = [];
+      if (batch.length > 0) {
+        renderDirtyMessages(batch);
       } else {
         renderMath();
       }

--- a/extension.test.js
+++ b/extension.test.js
@@ -359,10 +359,20 @@ describe('getMutationObserverScript', () => {
     expect(script).toContain('messageObserver.observe(activeContainer');
   });
 
-  test('processes only newly added nodes when possible', () => {
-    expect(script).toContain('renderNewNodes');
-    expect(script).toContain('m.addedNodes');
-    expect(script).toContain('node.isConnected');
+  test('bubbles mutations up to assistant-message boundary for per-message rendering', () => {
+    expect(script).toContain('renderDirtyMessages');
+    // Every mutation target is walked up to its assistant-message ancestor
+    // so that characterData mutations, text-node additions, and element
+    // additions are all handled uniformly. Falls back to the full container
+    // if the mutation isn't inside an assistant message.
+    expect(script).toContain('assistant-message');
+  });
+
+  test('accumulates mutations across debounced callbacks instead of overwriting', () => {
+    // Fixes a bug where the mutations closure captured only the latest batch,
+    // so rapid streaming callbacks would drop earlier mutations and most
+    // paragraphs would never get a render pass.
+    expect(script).toContain('pendingMutations');
   });
 
   test('checks hasMathContent before rendering a node', () => {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "claude-code-katex",
-  "displayName": "Claude Code KaTeX",
-  "description": "Adds LaTeX math rendering to Claude Code chat using KaTeX",
-  "version": "1.7.1",
+  "displayName": "Claude Code LaTeX (KaTeX)",
+  "description": "Adds LaTeX math rendering to Claude Code chat using KaTeX — inline $...$, display $$...$$, and \\(...\\) / \\[...\\]",
+  "version": "1.7.2",
   "publisher": "nuriyev",
   "license": "MIT",
   "icon": "icon.png",
@@ -17,13 +17,16 @@
     "Other"
   ],
   "keywords": [
-    "claude",
-    "katex",
     "latex",
     "math",
-    "rendering",
+    "mathematics",
+    "equations",
+    "katex",
+    "claude",
+    "claude-code",
     "anthropic",
-    "claude-code"
+    "markdown",
+    "rendering"
   ],
   "galleryBanner": {
     "color": "#1e1e2e",


### PR DESCRIPTION
## Summary

Streaming Claude Code responses with multiple math expressions rendered only the *last* paragraph's math; the rest stayed as raw `\$...\$` until the user reloaded the window. Reproducer: new chat → \"generate some latex equations\".

This PR replaces PR #3's 700ms polling workaround with a root-cause fix.

## Root cause

Two bugs in `getMutationObserverScript()` (previous `extension.js:344-397`):

1. **Debounce closure capture bug.** Each observer callback passed its `mutations` array to `debouncedRender(mutations)`. Each call overwrote the previous closure's `mutations` reference. When streaming emits 100+ characterData mutations in rapid succession, only the *last* batch survived the 200ms debounce — the earlier 99 batches were lost.
2. **`renderNewNodes` skipped text-node additions.** The addedNodes branch filtered on `node.nodeType === 1` (elements only), so any `childList` mutation whose added nodes were Text nodes (nodeType === 3) fell through silently. Several streaming DOM-update patterns produce exactly this kind of mutation.

The combined effect: during streaming, only whichever paragraph the final characterData batch happened to cover got rendered.

## Fix

- `debouncedRender` now accumulates mutations in a shared `pendingMutations` array across all callbacks. The timeout flushes the full batch.
- `renderNewNodes` replaced by `renderDirtyMessages`, which walks up from each mutation target to its `[data-testid=\"assistant-message\"]` ancestor and renders the whole message. Handles characterData, text-node additions, and element additions uniformly.
- Re-rendering already-rendered content stays effectively free: `renderMathInElement` skips `.katex` via `ignoredClasses`, and `preprocessMath` short-circuits blocks without `$`.

## Why not PR #3's approach

PR #3 adds a `setInterval(renderMath, 700)` rescue scan that *also* works. But:
- The PR's hypothesis (\"React Portal or virtualized list mount points outside activeContainer\") is wrong — I verified against Claude Code's webview bundle: messages render directly inside `messagesContainer_07S1Yg` via `E9.map(...)`, with no Portal usage for streamed content and no virtualization library.
- The actual cause is the debounce-closure bug above.
- Polling every 700ms forever is fine cost-wise but masks the real bug and adds a permanent background scan.

Credit to @yuan-qi5 in #3 for reporting and for the clear repro signal (\"rescued by conversation switch\").

## Verification

- All 73 Jest tests pass
- All 39 Playwright UI tests pass
- End-to-end in real VS Code + real Claude Code 2.1.116 + real API streaming on Lightning.ai code-server (drove via Playwright):
  - **Before fix:** katex=0, raw \$ signs=38, stuck until reload
  - **After fix:** katex=11, display=9, raw \$=0, renders as streaming completes

## Misc

- `displayName` updated to \"Claude Code LaTeX (KaTeX)\" and keywords reordered to surface in \"latex\" marketplace searches.

## Test plan
- [x] `npm test` passes (73/73)
- [x] `npm run test:ui` passes (39/39)
- [x] Real Claude Code streaming: math renders during stream, no reload needed
- [ ] Marketplace install, reload VS Code, ask \"generate some latex equations\", verify renders